### PR TITLE
Chromiumin maininta, ja ArchLinux-osio ChromeDriverin ohjeisiin

### DIFF
--- a/chromedriver_asennusohjeet.md
+++ b/chromedriver_asennusohjeet.md
@@ -11,7 +11,7 @@ permalink: /chromedriver_asennusohjeet/
 
 ## ChromeDriver-asennusohjeet
 
-Jos tietokoneellesi ei ole asennettu Chrome-selainta, aloita asentamalla sen viimeisin versio [täältä](https://www.google.com/chrome/). Lataa sen jälkeen käyttöjärjestelmällesi ja Chrome-versiollesi sopiva _chromedriver_-binääri [täältä](https://chromedriver.chromium.org/downloads). Pura ladattu paketti ja noudata sen jälkeen käyttöjärjestelmäkohtaisia ohjeita.
+Jos tietokoneellesi ei ole asennettu Chrome- tai Chromium-selainta, aloita asentamalla sen viimeisin versio [täältä](https://www.google.com/chrome/). ChromeDriverin käyttöön soveltuu myös [Chromium](https://www.chromium.org/chromium-projects/), joka on avoimen lähdekoodin selain, johon Google Chrome pohjautuu. Lataa sen jälkeen käyttöjärjestelmällesi ja Chrome-versiollesi sopiva _chromedriver_-binääri [täältä](https://chromedriver.chromium.org/downloads). Pura ladattu paketti ja noudata sen jälkeen käyttöjärjestelmäkohtaisia ohjeita.
 
 _Huom:_ valitse Chrome driverista versio joka on yhteensopiva käyttämäsi Chromen version mukaan!
 
@@ -28,6 +28,10 @@ chromedriver --version
 ```
 
 **HUOM:** Mac-käyttäjänä saatat törmätä tilanteeseen, jossa chromedriverin käynnistys epäonnistuu koska kone ei tiedä että chromedriver on luotettavan tahon tekemä ohjelma. Ongelma korjautuu [tämän ohjeen](https://timonweb.com/misc/fixing-error-chromedriver-cannot-be-opened-because-the-developer-cannot-be-verified-unable-to-launch-the-chrome-browser-on-mac-os/) avulla.
+
+#### ArchLinux
+
+**ArchLinux**-distributiossa [`chromium`](https://archlinux.org/packages/extra/x86_64/chromium/)-paketin mukana tulee ChromeDriver suoraan. Jos sen sijaan on asennettuna [`google-chrome`](https://aur.archlinux.org/packages/google-chrome) Arch User Repositorioista, ChromeDriverin saa [`chromedriver`](https://aur.archlinux.org/packages/chromedriver)-paketista.
 
 ### Windows
 

--- a/tehtavat3.md
+++ b/tehtavat3.md
@@ -389,7 +389,7 @@ Jatketaan saman sovelluksen parissa.
 
 [Selenium WebDriver](http://docs.seleniumhq.org/projects/webdriver/) -kirjaston avulla on mahdollista simuloida selaimen käyttöä koodista käsin. Seleniumin käyttö Robot Framework -testeissä onnistuu valmiin, [SeleniumLibrary](https://robotframework.org/SeleniumLibrary/)-kirjaston avulla.
 
-Jotta selainta käyttävien testien suorittamien on mahdollista, täytyy lisäksi asentaa halutun selaimen ajuri. Projektin testit käyttävät Chrome-selainta, jolla testejä voi suorittaa käyttämällä [ChromeDriver](https://chromedriver.chromium.org/)-ajuria. Ennen kuin siirrymme testien pariin, asenna ChromeDriver seuraamalla [tätä](../chromedriver_asennusohjeet) ohjetta.
+Jotta selainta käyttävien testien suorittamien on mahdollista, täytyy lisäksi asentaa halutun selaimen ajuri. Projektin testit käyttävät Chrome- tai Chromium-selainta, jolla testejä voi suorittaa käyttämällä [ChromeDriver](https://chromedriver.chromium.org/)-ajuria. Ennen kuin siirrymme testien pariin, asenna ChromeDriver seuraamalla [tätä](../chromedriver_asennusohjeet) ohjetta.
 
 Kun Chrome-ajuri on asennettu onnistuneesti, **avaa uusi terminaali-ikkuna** ja suorita projektin testit virtuaaliympäristössä komennolla `robot src/tests`. Huomaa, että web-sovelluksen tulee olla käynnissä toisessa terminaali-ikkunassa. Komennon pitäisi suorittaa onnistuneesti kaksi testitapausta, `Login With Correct Credentials` ja `Login With Incorrect Password`. Testitapausten suoritusta voi seurata aukeavasta Chrome-selaimen ikkunasta.
 


### PR DESCRIPTION
Tämä PR lisää erityismaininnan sekä Tehtävän 3 ohjeeseen relevanttiin kohtaan, sekä varsinaiseen ChromeDriverin-asennusohjeisiin siitä, että ChromeDriverin käyttöön soveltuu Google Chromen lisäksi myös Chromium.

Lisäksi tämä PR lisää ChromeDriverin `macOS ja Linux` asennusohjeisiin `ArchLinux`-alaotsikon, koska itse käytän ArchLinuxia, ja ajattelin lisätä sen samalla kun muutenkin tein PR:ää.