### PR TITLE
Update tehtavat1.md

### DIFF
--- a/tehtavat1.md
+++ b/tehtavat1.md
@@ -633,7 +633,7 @@ Samme muodostettua Codecovin ymm채rt채m채n testikattavuusraportin k채ytt채m채ll�
 - name: Coverage report
   run: poetry run coverage xml
 - name: Coverage report to Codecov
-  run: bash <(curl -s https://codecov.io/bash)
+  run: bash <(curl -s https://codecov.io/bash) -Z
 ```
 
 **HUOM1** rivit on sisennett채v채 samalle tasolle kuin muut stepit.


### PR DESCRIPTION
Normaalisti jos Codecoviin lähetys ei onnistu, niin buildi menee läpi. 

> Codecov will exit 0 to prevent failing the build, if there are issues. If you would like Codecov to exit with 1, use `bash <(curl -s https://codecov.io/bash) -Z`
[https://docs.codecov.com/docs/about-the-codecov-bash-uploader#uploading-process](https://docs.codecov.com/docs/about-the-codecov-bash-uploader#uploading-process)

Jos perään laittaa -Z niin näkee heti jos upload ei onnistunut.

e: paitsi tietenkin jos pääasia on suorittaa testit ja mahdollisesti lähettää codecoviin, niin en tiedä onko tässä järkeä