### PR TITLE
Fix typos/wording and added info in miniprojekti.md

### DIFF
--- a/miniprojekti.md
+++ b/miniprojekti.md
@@ -19,7 +19,7 @@ permalink: /miniprojekti/
   - to 14.12 klo 12-14
 - **Ilmoittautuminen miniprojektiin käynnissä ja päättyy lauantaina 11.11. klo 23.59**
 - Ilmoittaudu [täällä](https://study.cs.helsinki.fi/assembler/course/4f142151-b6e2-4120-b677-d1ae259ef6a8)
--  [Arvosteluperusteet](/miniprojektin_arvosteluperusteet/)
+- [Arvosteluperusteet](/miniprojektin_arvosteluperusteet/)
 
 ### Johdanto
 
@@ -35,7 +35,7 @@ permalink: /miniprojekti/
 
 ### Ryhmän muodostaminen
 
-- Ryhmät muodostetaan sunnuntaina 12.11. "algoritmisesti", pääasiassa noudattaen ilmoittautumisessa  kerrottuja sopivia työskentelyaikoja
+- Ryhmät muodostetaan sunnuntaina 12.11. "algoritmisesti", pääasiassa noudattaen ilmoittautumisessa kerrottuja sopivia työskentelyaikoja
 - Ryhmäsi aloitustilaisuuden ajankohta selviää ilmoittautumissovelluksesta. Kaikkien ryhmäläisten on **pakko osallistua** tilaisuuteen, jonka kesto on noin 2 tuntia
 - Aloitustilaisuuteen tullessa on syytä tuntea materiaalin osien 1 ja 2 asioista ainakin seuraavat:
   - Scrum
@@ -98,7 +98,7 @@ Selviää aloitustilaisuudessa...
     - taskin tila (esim. aloitettu, ohjelmoitu, testauksessa, valmis)
     - taskin tekijä(t)
 - Ryhmä toteuttaa jatkuvaa integraatiota (continuous integration)
-  - Oletusarvoisesti kannattaa käyttää laskareista 1 tuttua GitHub Actionsia 
+  - Oletusarvoisesti kannattaa käyttää laskareista 1 tuttua GitHub Actionsia
 - Koodi on talletettu GitHubiin
 - Projektin GitHub-repositoriolla on järkevä README.md
 
@@ -140,13 +140,13 @@ README:ssa tulee löytyä ainakin seuraavat asiat:
 - Jos kyse työpöytäsovelluksesta, tulee ohjelmalle olla asennus- ja käyttöohje
 - Työlle tulee määritellä lisenssi <https://help.github.com/articles/licensing-a-repository/>
 
-### Viheitä ryhmätyöskentelyyn
+### Vihjeitä ryhmätyöskentelyyn
 
-Melko varma resepti epäonnistumiseen on huono kommunikaatio. Tehkää siis asioita mahdollisimman paljon yhdessä, mieluiten paikanpäällä tai jos se ei onnistu niin esim. Discordin voice chatissa. Erityisesti projektin alkuvaiheessa esim. GitHub-actionsia konfiguroitaessa yhdessä tapahtuvaan työskentelyyn kannattaa panostaa. Projektin kuluessa omatoiminenkin työskentely muuttuu jo helpommaksi jos ja kun ryhmä on sopinut työskentelyn periaatteista ja pelisäännöistä.
+Melko varma resepti epäonnistumiseen on huono kommunikaatio. Tehkää siis asioita mahdollisimman paljon yhdessä, mieluiten paikanpäällä tai jos se ei onnistu niin esim. Discordin voice chatissa. Ylipäänsä on hyvä kommunikoida ryhmälle mitä lähtee tekemään ja milloin on saanut sen valmiiksi, tällöin vältytään päällekkäisyyksiltä. Erityisesti projektin alkuvaiheessa esim. GitHub-actionsia konfiguroitaessa yhdessä tapahtuvaan työskentelyyn kannattaa panostaa. Projektin kuluessa omatoiminenkin työskentely muuttuu jo helpommaksi jos ja kun ryhmä on sopinut työskentelyn periaatteista ja pelisäännöistä.
 
 Pariohjelmointi/konfigurointi on havaittu erittäin hyödylliseksi. Voikin olla hyvä idea, että jokaista user storyä työstää aina kaksi henkilöä.
 
-Jokaiselle asialle, kuten vaikkapa README.md-tiedostolle, project backlogille ja sprint backlogille kannattanee nimetä joku vastuuhenkilö joka varmistaa, että ryhmä on hoitaa asian. Asian X vastuuhenkilö ei välttämättä siis tee asia itse, vaan varmistaa että se tulee tehdyksi.
+Jokaiselle asialle, kuten vaikkapa README.md-tiedostolle, project backlogille ja sprint backlogille kannattanee nimetä joku vastuuhenkilö joka varmistaa, että ryhmä hoitaa asian. Asian X vastuuhenkilö ei välttämättä siis tee asiaa itse, vaan varmistaa että se tulee tehdyksi.
 
 Pitäkää ohjelma koko ajan toimintakykyisenä. On erittäin huono idea koittaa saada viikon aikana eri ihmisten koodaamat tuotokset integroitua tunti ennen asiakaspalaveria...
 


### PR DESCRIPTION
Väliotsikko `Viheitä ryhmätyöskentelyyn` -> `Vihjeitä ryhmätyöskentelyyn`.

Poistettu turha `on` ja `asia` -> `asiaa`, jotta lauserakenteet ovat järkeviä.

Lisätty `Vihjeitä ryhmätyöskentelyyn` -osioon myös maininta omasta "statuksesta", jonka kommunikointi ryhmätyöskentelyssä on tärkeää, jotta ryhmä välttyy tekemästä päällekkäin samoja asioita.