### PR TITLE
Instruction to check ChromeDriver installation first

### DIFF
--- a/tehtavat3.md
+++ b/tehtavat3.md
@@ -324,7 +324,7 @@ Jatketaan siis saman sovelluksen parissa.
 
 Jotta selainta käyttävien testien suorittamien on mahdollista, täytyy lisäksi asentaa halutun selaimen ajuri. Projektin testit käyttävät Chrome- tai Chromium-selainta, jolla testejä voi suorittaa käyttämällä [ChromeDriver](https://chromedriver.chromium.org/)-ajuria, tai Firefoxia jolloin testit voi suorittaa [Geckodriverillä](https://github.com/mozilla/geckodriver).
 
-**Ennen kuin siirryt testien pariin, asenna ChromeDriver** tai **Geckodriver** seuraamalla [tätä](../chromedriver_asennusohjeet) ohjetta.
+**Ennen kuin siirryt testien pariin, asenna ChromeDriver** tai **Geckodriver** seuraamalla [tätä](../chromedriver_asennusohjeet) ohjetta. Fuksiläppärillä ChromeDriver saattaa olla jo asennettuna. Voit tarkistaa tämän komennolla ```chromedriver --version```
 
 Kun ChromeDriver tai GeckoDriver on asennettu onnistuneesti, **avaa uusi terminaali-ikkuna** ja suorita projektin testit virtuaaliympäristössä komennolla `robot src/tests`. Huomaa, että web-sovelluksen tulee olla käynnissä toisessa terminaali-ikkunassa. Komennon pitäisi suorittaa onnistuneesti kaksi testitapausta, `Login With Correct Credentials` ja `Login With Incorrect Password`. Testitapausten suoritusta voi seurata aukeavasta selaimen ikkunasta.
 


### PR DESCRIPTION
Ajantasaisella fuksiläppärillä ChromeDriver näytti olevan jo asennettuna. Ehdotan, että ennen kuin opastetaan, miten ChromeDriver asennetaan, kehotetaan tarkastamaan onko ChromeDriver jo asennettu komennolla chromedriver --version.