### PR TITLE
Proposition to fix a typo in tehtavat1.md

### DIFF
--- a/tehtavat1.md
+++ b/tehtavat1.md
@@ -5,6 +5,7 @@ inheader: no
 permalink: /tehtavat1
 ---
 
+This part doesn't show correctly!
 {% include laskari_info.md part=1 %}
 
 Tämän viikon tehtävissä harjoitellaan ensin muutaman tärkeän ohjelmistokehityksen työkalun (_komentorivi, versionhallinta, riippuvuuksien hallinta, automatisoitu testaus, jatkuva integraatio_) käyttöä.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1f6dfb5f-52e6-4e48-ba99-d50f18c19c9f)

Some parts of the file don't show to me correctly when i view it online. I suppose that for instance {% include laskari_info.md part=1 %} should show up as the laskari_info.md file itself and not as text. If there is a way to see the attached file in a correct way, it should be mentioned on this page.
